### PR TITLE
Remove duplicate coverage ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,7 +60,6 @@ yarn-error.log
 /.nx
 /.nx/cache
 /connect.lock
-/coverage
 /libpeerconnection.log
 testem.log
 /typings


### PR DESCRIPTION
## Summary
- keep `.gitignore` concise by removing the duplicate `/coverage` entry

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6853b5c1237c832b87be4e6ae3e5c0c7